### PR TITLE
HTTP Error Alert Interceptor

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,6 +25,7 @@
               "src/assets"
             ],
             "styles": [
+              "@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.css"
             ],
             "scripts": []
@@ -87,6 +88,7 @@
               "src/assets"
             ],
             "styles": [
+              "@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.css"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^16.2.0",
+        "@angular/cdk": "^16.2.14",
         "@angular/common": "^16.2.0",
         "@angular/compiler": "^16.2.0",
         "@angular/core": "^16.2.0",
         "@angular/forms": "^16.2.0",
+        "@angular/material": "^16.2.14",
         "@angular/platform-browser": "^16.2.0",
         "@angular/platform-browser-dynamic": "^16.2.0",
         "@angular/router": "^16.2.0",
@@ -268,6 +270,34 @@
         "@angular/core": "16.2.12"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-16.2.14.tgz",
+      "integrity": "sha512-n6PrGdiVeSTEmM/HEiwIyg6YQUUymZrb5afaNLGFRM5YL0Y8OBqd+XhCjb0OfD/AfgCUtedVEPwNqrfW8KzgGw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/cdk/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "optional": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "16.2.12",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-16.2.12.tgz",
@@ -467,6 +497,70 @@
         "@angular/common": "16.2.12",
         "@angular/core": "16.2.12",
         "@angular/platform-browser": "16.2.12",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-16.2.14.tgz",
+      "integrity": "sha512-zQIxUb23elPfiIvddqkIDYqQhAHa9ZwMblfbv+ug8bxr4D0Dw360jIarxCgMjAcLj7Ccl3GBqZMUnVeM6cjthw==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/auto-init": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/banner": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/card": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/chips": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/circular-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/data-table": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dialog": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/drawer": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/fab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/form-field": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/image-list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/layout-grid": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/radio": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/segmented-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/slider": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/snackbar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/switch": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/textfield": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tooltip": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/top-app-bar": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^16.0.0 || ^17.0.0",
+        "@angular/cdk": "16.2.14",
+        "@angular/common": "^16.0.0 || ^17.0.0",
+        "@angular/core": "^16.0.0 || ^17.0.0",
+        "@angular/forms": "^16.0.0 || ^17.0.0",
+        "@angular/platform-browser": "^16.0.0 || ^17.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2912,6 +3006,758 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "node_modules/@material/animation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-leRf+BcZTfC/iSigLXnYgcHAGvFVQveoJT5+2PIRdyPI/bIG7hhciRgacHRsCKC0sGya81dDblLgdkjSUemYLw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/auto-init": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/auto-init/-/auto-init-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uxzDq7q3c0Bu1pAsMugc1Ik9ftQYQqZY+5e2ybNplT8gTImJhNt4M2mMiMHbMANk2l3UgICmUyRSomgPBWCPIA==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/banner": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/banner/-/banner-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SHeVoidCUFVhXANN6MNWxK9SZoTSgpIP8GZB7kAl52BywLxtV+FirTtLXkg/8RUkxZRyRWl7HvQ0ZFZa7QQAyA==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/base": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Fc3vGuOf+duGo22HTRP6dHdc+MUe0VqQfWOuKrn/wXKD62m0QQR2TqJd3rRhCumH557T5QUyheW943M3E+IGfg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AQgwrPZCTWHDJvwgKq7Cj+BurQ4wTjDdGL+FEnIGUAjJDskwi1yzx5tW2Wf/NxIi7IoPFyOY3UB41jwMiOrnw==",
+      "dependencies": {
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/card": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/card/-/card-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nPlhiWvbLmooTnBmV5gmzB0eLWSgLKsSRBYAbIBmO76Okgz1y+fQNLag+lpm/TDaHVsn5fmQJH8e0zIg0rYsQA==",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/checkbox": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/checkbox/-/checkbox-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-4tpNnO1L0IppoMF3oeQn8F17t2n0WHB0D7mdJK9rhrujen/fLbekkIC82APB3fdGtLGg3qeNqDqPsJm1YnmrwA==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/chips": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/chips/-/chips-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-fqHKvE5bSWK0bXVkf57MWxZtytGqYBZvvHIOs4JI9HPHEhaJy4CpSw562BEtbm3yFxxALoQknvPW2KYzvADnmA==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/circular-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/circular-progress/-/circular-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Lxe8BGAxQwCQqrLhrYrIP0Uok10h7aYS3RBXP41ph+5GmwJd5zdyE2t93qm2dyThvU6qKuXw9726Dtq/N+wvZQ==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/data-table": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/data-table/-/data-table-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-j/7qplT9+sUpfe4pyWhPbl01qJA+OoNAG3VMJruBBR461ZBKyTi7ssKH9yksFGZ8eCEPkOsk/+kDxsiZvRWkeQ==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/checkbox": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/linear-progress": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/select": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/density": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Zt3u07fXrBWLW06Tl5fgvjicxNQMkFdawLyNTzZ5TvbXfVkErILLePwwGaw8LNcvzqJP6ABLA8jiR+sKNoJQCg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dialog": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-o+9a/fmwJ9+gY3Z/uhj/PMVJDq7it1NTWKJn2GwAKdB+fDkT4hb9qEdcxMPyvJJ5ups+XiKZo03+tZrD+38c1w==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/dom": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ly78R7aoCJtundSUu0UROU+5pQD5Piae0Y1MkN6bs0724azeazX1KeXFeaf06JOXnlr5/41ol+fSUPowjoqnOg==",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/drawer": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-PFL4cEFnt7VTxDsuspFVNhsFDYyumjU0VWfj3PWB7XudsEfQ3lo85D3HCEtTTbRsCainGN8bgYNDNafLBqiigw==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/elevation": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Ro+Pk8jFuap+T0B0shA3xI1hs2b89dNQ2EIPCNjNMp87emHKAzJfhKb7EZGIwv3+gFLlVaLyIVkb94I89KLsyg==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/fab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/fab/-/fab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dvU0KWMRglwJEQwmQtFAmJcAjzg9VFF6Aqj78bJYu/DAIGFJ1VTTTSgoXM/XCm1YyQEZ7kZRvxBO37CH54rSDg==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/feature-targeting": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-wkDjVcoVEYYaJvun28IXdln/foLgPD7n9ZC9TY76GErGCwTq+HWpU6wBAAk+ePmpRFDayw4vI4wBlaWGxLtysQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/floating-label": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/floating-label/-/floating-label-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-bUWPtXzZITOD/2mkvLkEPO1ngDWmb74y0Kgbz6llHLOQBtycyJIpuoQJ1q2Ez0NM/tFLwPphhAgRqmL3YQ/Kzw==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-cZHThVose3GvAlJzpJoBI1iqL6d1/Jj9hXrR+r8Mwtb1hBIUEG3hxfsRd4vGREuzROPlf0OgNf/V+YHoSwgR5w==",
+      "dependencies": {
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/form-field": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/form-field/-/form-field-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-+JFXy5X44Gue1CbZZAQ6YejnI203lebYwL0i6k0ylDpWHEOdD5xkF2PyHR28r9/65Ebcbwbff6q7kI1SGoT7MA==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/icon-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-1a0MHgyIwOs4RzxrVljsqSizGYFlM1zY2AZaLDsgT4G3kzsplTx8HZQ022GpUCjAygW+WLvg4z1qAhQHvsbqlw==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/image-list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/image-list/-/image-list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WKWmiYap2iu4QdqmeUSliLlN4O2Ueqa0OuVAYHn/TCzmQ2xmnhZ1pvDLbs6TplpOmlki7vFfe+aSt5SU9gwfOQ==",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/layout-grid": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/layout-grid/-/layout-grid-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-5GqmT6oTZhUGWIb+CLD0ZNyDyTiJsr/rm9oRIi3+vCujACwxFkON9tzBlZohdtFS16nuzUusthN6Jt9UrJcN6Q==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/line-ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/line-ripple/-/line-ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-8S30WXEuUdgDdBulzUDlPXD6qMzwCX9SxYb5mGDYLwl199cpSGdXHtGgEcCjokvnpLhdZhcT1Dsxeo1g2Evh5Q==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/linear-progress": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/linear-progress/-/linear-progress-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-6EJpjrz6aoH2/gXLg9iMe0yF2C42hpQyZoHpmcgTLKeci85ktDvJIjwup8tnk8ULQyFiGiIrhXw2v2RSsiFjvQ==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/progress-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/list": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TQ1ppqiCMQj/P7bGD4edbIIv4goczZUoiUAaPq/feb1dflvrFMzYqJ7tQRRCyBL8nRhJoI2x99tk8Q2RXvlGUQ==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu/-/menu-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-IlAh61xzrzxXs38QZlt74UYt8J431zGznSzDtB1Fqs6YFNd11QPKoiRXn1J2Qu/lUxbFV7i8NBKMCKtia0n6/Q==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/menu-surface": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/menu-surface/-/menu-surface-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-dMtSPN+olTWE+08M5qe4ea1IZOhVryYqzK0Gyb2u1G75rSArUxCOB5rr6OC/ST3Mq3RS6zGuYo7srZt4534K9Q==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/notched-outline": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/notched-outline/-/notched-outline-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-WuurMg44xexkvLTBTnsO0A+qnzFjpcPdvgWBGstBepYozsvSF9zJGdb1x7Zv1MmqbpYh/Ohnuxtb/Y3jOh6irg==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/progress-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/progress-indicator/-/progress-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-uOnsvqw5F2fkeTnTl4MrYzjI7KCLmmLyZaM0cgLNuLsWVlddQE+SGMl28tENx7DUK3HebWq0FxCP8f25LuDD+w==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/radio": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-ehzOK+U1IxQN+OQjgD2lsnf1t7t7RAwQzeO6Czkiuid29ookYbQynWuLWk7NW8H8ohl7lnmfqTP1xSNkkL/F0g==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/ripple": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-JfLW+g3GMVDv4cruQ19+HUxpKVdWCldFlIPw1UYezz2h3WTNDy05S3uP2zUdXzZ01C3dkBFviv4nqZ0GCT16MA==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/rtl": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-SkKLNLFp5QtG7/JEFg9R92qq4MzTcZ5As6sWbH7rRg6ahTHoJEuqE+pOb9Vrtbj84k5gtX+vCYPvCILtSlr2uw==",
+      "dependencies": {
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/segmented-button": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/segmented-button/-/segmented-button-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-YDwkCWP9l5mIZJ7pZJZ2hMDxfBlIGVJ+deNzr8O+Z7/xC5LGXbl4R5aPtUVHygvXAXxpf5096ZD+dSXzYzvWlw==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/touch-target": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/select": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/select/-/select-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-unfOWVf7T0sixVG+3k3RTuATfzqvCF6QAzA6J9rlCh/Tq4HuIBNDdV4z19IVu4zwmgWYxY0iSvqWUvdJJYwakQ==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/list": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/menu-surface": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/shape": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Dsvr771ZKC46ODzoixLdGwlLEQLfxfLrtnRojXABoZf5G3o9KtJU+J+5Ld5aa960OAsCzzANuaub4iR88b1guA==",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/slider": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/slider/-/slider-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-3AEu+7PwW4DSNLndue47dh2u7ga4hDJRYmuu7wnJCIWJBnLCkp6C92kNc4Rj5iQY2ftJio5aj1gqryluh5tlYg==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/snackbar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/snackbar/-/snackbar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-TwwQSYxfGK6mc03/rdDamycND6o+1p61WNd7ElZv1F1CLxB4ihRjbCoH7Qo+oVDaP8CTpjeclka+24RLhQq0mA==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/icon-button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/switch": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/switch/-/switch-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-OjUjtT0kRz1ASAsOS+dNzwMwvsjmqy5edK57692qmrP6bL4GblFfBDoiNJ6t0AN4OaKcmL5Hy/xNrTdOZW7Qqw==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-s/L9otAwn/pZwVQZBRQJmPqYeNbjoEbzbjMpDQf/VBG/6dJ+aP03ilIBEkqo8NVnCoChqcdtVCoDNRtbU+yp6w==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/focus-ring": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-Xmtq0wJGfu5k+zQeFeNsr4bUKv7L+feCmUp/gsapJ655LQKMXOUQZtSv9ZqWOfrCMy55hoF1CzGFV+oN3tyWWQ==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-indicator": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab-scroller": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-indicator": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-despCJYi1GrDDq7F2hvLQkObHnSLZPPDxnOzU16zJ6FNYvIdszgfzn2HgAZ6pl5hLOexQ8cla6cAqjTDuaJBhQ==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tab-scroller": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-QWHG/EWxirj4V9u2IHz+OSY9XCWrnNrPnNgEufxAJVUKV/A8ma1DYeFSQqxhX709R8wKGdycJksg0Flkl7Gq7w==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tab": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/textfield": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/textfield/-/textfield-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-R3qRex9kCaZIAK8DuxPnVC42R0OaW7AB7fsFknDKeTeVQvRcbnV8E+iWSdqTiGdsi6QQHifX8idUrXw+O45zPw==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/density": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/floating-label": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/line-ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/notched-outline": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/theme": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CpUwXGE0dbhxQ45Hu9r9wbJtO/MAlv5ER4tBHA9tp/K+SU+lDgurBE2touFMg5INmdfVNtdumxb0nPPLaNQcUg==",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-nbEuGj05txWz6ZMUanpM47SaAD7soyjKILR+XwDell9Zg3bGhsnexCNXPEz2fD+YgomS+jM5XmIcaJJHg/H93Q==",
+      "dependencies": {
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0"
+      }
+    },
+    "node_modules/@material/tooltip": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/tooltip/-/tooltip-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-UzuXp0b9NuWuYLYpPguxrjbJnCmT/Cco8CkjI/6JajxaeA3o2XEBbQfRMTq8PTafuBjCHTc0b0mQY7rtxUp1Gg==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/button": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/dom": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/tokens": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "safevalues": "^0.3.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/top-app-bar": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-vJWjsvqtdSD5+yQ/9vgoBtBSCvPJ5uF/DVssv8Hdhgs1PYaAcODUi77kdi0+sy/TaWyOsTkQixqmwnFS16zesA==",
+      "dependencies": {
+        "@material/animation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/elevation": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/ripple": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/shape": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/typography": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/touch-target": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-AqYh9fjt+tv4ZE0C6MeYHblS2H+XwLbDl2mtyrK0DOEnCVQk5/l5ImKDfhrUdFWHvS4a5nBM4AA+sa7KaroLoA==",
+      "dependencies": {
+        "@material/base": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/rtl": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/typography": {
+      "version": "15.0.0-canary.bc9ae6c9c.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-15.0.0-canary.bc9ae6c9c.0.tgz",
+      "integrity": "sha512-CKsG1zyv34AKPNyZC8olER2OdPII64iR2SzQjpqh1UUvmIFiMPk23LvQ1OnC5aCB14pOXzmVgvJt31r9eNdZ6Q==",
+      "dependencies": {
+        "@material/feature-targeting": "15.0.0-canary.bc9ae6c9c.0",
+        "@material/theme": "15.0.0-canary.bc9ae6c9c.0",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/@ngtools/webpack": {
       "version": "16.2.12",
@@ -5719,7 +6565,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -10647,6 +11493,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/safevalues": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.3.4.tgz",
+      "integrity": "sha512-LRneZZRXNgjzwG4bDQdOTSbze3fHm1EAKN/8bePxnlEZiBmkYEDggaHbuvHI9/hoqHbGfsEA7tWS9GhYHZBBsw=="
     },
     "node_modules/sass": {
       "version": "1.64.1",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^16.2.0",
+    "@angular/cdk": "^16.2.14",
     "@angular/common": "^16.2.0",
     "@angular/compiler": "^16.2.0",
     "@angular/core": "^16.2.0",
     "@angular/forms": "^16.2.0",
+    "@angular/material": "^16.2.14",
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,9 @@ import { UserpanelComponent } from './components/userpanel/userpanel.component';
 import { AdminpanelComponent } from './components/adminpanel/adminpanel.component';
 import { CreateBankAccountComponent } from './components/create-bank-account/create-bank-account.component';
 import { CreateBankProfileComponent } from './components/create-bank-profile/create-bank-profile.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import {AlertInterceptor} from "./interceptors/alert.interceptor";
+import {HTTP_INTERCEPTORS} from "@angular/common/http";
 
 @NgModule({
   declarations: [
@@ -24,9 +27,14 @@ import { CreateBankProfileComponent } from './components/create-bank-profile/cre
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    BrowserAnimationsModule
   ],
-  providers: [],
+  providers: [{
+    provide: HTTP_INTERCEPTORS,
+    useClass: AlertInterceptor,
+    multi: true
+  }],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/src/app/interceptors/alert.interceptor.ts
+++ b/src/app/interceptors/alert.interceptor.ts
@@ -1,18 +1,54 @@
-import { Injectable } from '@angular/core';
-import {
-  HttpRequest,
-  HttpHandler,
-  HttpEvent,
-  HttpInterceptor
-} from '@angular/common/http';
-import { Observable } from 'rxjs';
+import {inject, Injectable} from '@angular/core';
+import {HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
+import {catchError, Observable} from 'rxjs';
+import {MatSnackBar} from "@angular/material/snack-bar";
 
 @Injectable()
 export class AlertInterceptor implements HttpInterceptor {
 
+  private snackBar = inject(MatSnackBar);
   constructor() { }
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    return next.handle(request);
+    return next.handle(request).pipe(
+      catchError((error: HttpErrorResponse) => {
+          let errorMessage = "An unknown error occurred!";
+
+          if (error.error instanceof ErrorEvent) {
+            // Client-side errors
+            errorMessage = `${error.error.message}`;
+          } else {
+            // Server-side errors
+            switch (error.status) {
+              case 401:
+                errorMessage = "Unauthorized access!";
+                // can possibly redirect to login page
+                break;
+              case 403:
+                errorMessage = "Access denied!";
+                // can possibly redirect to forbidden page
+                break;
+              case 404:
+                errorMessage = "Resource not found!";
+                break;
+              case 500:
+                errorMessage = "Internal server error!";
+                break;
+              default:
+                errorMessage = `${error.message}`;
+                break;
+            }
+          }
+
+          this.snackBar.open(errorMessage, "Close", {
+            duration: 2000,
+            verticalPosition: 'top',
+            horizontalPosition: 'right'
+          });
+
+          throw error;
+        }
+      )
+    )
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,9 @@
   <base href="/">
   <meta content="width=device-width, initial-scale=1" name="viewport">
   <link href="favicon.ico" rel="icon" type="image/x-icon">
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 
 <body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
+html, body { height: 100%; }
+body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
### **WARNING:** Installed Angular Material using `ng add @angular/material`  (needed for SnackBar)
Selected the `deep purple amber theme`
The installation script added the font settings.

- I created an HTTP Interceptor and handled client-side and server-side errors.
- I created custom messages for common error codes and a default case for the custom messages from the backend.
- When creating the interceptor, I have used this for reference: [https://medium.com/nerd-for-tech/angular-interceptors-for-errors-and-headers-a35372f4304b](url)

Issue: [https://github.com/RAF-SI-2023/Banka-2-Frontend/issues/11](url)

